### PR TITLE
gpio-ffi: use uint32_t everywhere for rpi4 64bit compat

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,6 +4,6 @@
 from cffi import FFI
 
 ffibuilder = FFI()
-ffibuilder.cdef("unsigned int pi_mmio_init(unsigned int base); int jtag_pins(int tdi, int tms, unsigned int gpio); int jtag_prog(char *bitstream, unsigned int gpio); void jtag_prog_rbk(char *bitstream, unsigned int gpio, char *readback);")
+ffibuilder.cdef("volatile uint32_t *pi_mmio_init(uint32_t base); int jtag_pins(int tdi, int tms, volatile uint32_t *gpio); int jtag_prog(char *bitstream, volatile uint32_t *gpio); void jtag_prog_rbk(char *bitstream, volatile uint32_t *gpio, char *readback);")
 ffibuilder.set_source("gpioffi", '#include "gpio-ffi.h"', sources=["gpio-ffi.c"])
 ffibuilder.compile()

--- a/gpio-ffi.h
+++ b/gpio-ffi.h
@@ -1,6 +1,6 @@
 #include <sys/types.h>
 #include <stdint.h>
-uintptr_t pi_mmio_init(off_t base);
-int jtag_pins(int tdi, int tms, uintptr_t gpio);
-int jtag_prog(char *bitstream, uintptr_t gpio);
-void jtag_prog_rbk(char *bitstream, uintptr_t gpio, char *readback);
+volatile uint32_t *pi_mmio_init(uint32_t base);
+int jtag_pins(int tdi, int tms, volatile uint32_t *gpio);
+int jtag_prog(char *bitstream, volatile uint32_t *gpio);
+void jtag_prog_rbk(char *bitstream, volatile uint32_t *gpio, char *readback);


### PR DESCRIPTION
Tested with:
```
Linux raspberrypi 5.10.92-v8+ #1514 SMP PREEMPT Mon Jan 17 17:39:38 GMT 2022 aarch64 GNU/Linux
```

Fixes https://github.com/betrusted-io/betrusted-scripts/issues/7