### PR TITLE
fhs: fix jtag_gpio assumptions

### DIFF
--- a/jtag_gpio.py
+++ b/jtag_gpio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 try:
     import RPi.GPIO as GPIO


### PR DESCRIPTION
fhseries is the term *I use* to design strong Filesystem Hierarchy Standard assumptions, which are not true on all Linux distributions. Notably: NixOS and Guix.

This does not hamper the functionality of the script on previous system and just increase its portability.